### PR TITLE
Exchange Rate Sources: Add CleverCoin

### DIFF
--- a/Airbitz/Settings/SettingsViewController.m
+++ b/Airbitz/Settings/SettingsViewController.m
@@ -77,7 +77,7 @@
 #define ROW_PIN_RELOGIN                 7
 #define ROW_TOUCHID                     8
 
-#define ARRAY_EXCHANGES     @[@"Bitstamp", @"BraveNewCoin", @"Coinbase"]
+#define ARRAY_EXCHANGES     @[@"Bitstamp", @"BraveNewCoin", @"Coinbase", @"CleverCoin"]
 
 #define ARRAY_LOGOUT        @[@[@"1",@"2",@"3",@"4",@"5",@"6",@"7",@"8",@"9", \
                                 @"10",@"11",@"12",@"13",@"14",@"15",@"16",@"17",@"18",@"19", \


### PR DESCRIPTION
Needs to be merged after Core PR:
Airbitz/airbitz-core-private#24

Couldn't test this PR, but I looking at the other exchanges in the source code I think this is the only change that is needed to add CC.
